### PR TITLE
Sessionless CSRF

### DIFF
--- a/add_login.js
+++ b/add_login.js
@@ -54,8 +54,8 @@ function buildLoginElement(idx) {
 }
 
 function activateLoginWithAmazonButtons(elementId) {
-    var cfg = window.loginwithamazon_config;
     document.getElementById(elementId).onclick = function() {
+        var cfg = window.loginwithamazon_config;
         amazon.Login.authorize( cfg.options, cfg.redirect );
         return false;
     };

--- a/add_login.js
+++ b/add_login.js
@@ -54,6 +54,7 @@ function buildLoginElement(idx) {
 }
 
 function activateLoginWithAmazonButtons(elementId) {
+    var cfg = window.loginwithamazon_config;
     document.getElementById(elementId).onclick = function() {
         amazon.Login.authorize( cfg.options, cfg.redirect );
         return false;
@@ -61,6 +62,7 @@ function activateLoginWithAmazonButtons(elementId) {
 }
 
 function loginwithamazon_loader( cfg ) {
+    window.loginwithamazon_config = cfg;
     window.onAmazonLoginReady = function() {
         amazon.Login.setClientId(cfg.client_id);
         amazon.Login.setUseCookie(true);

--- a/add_login.js
+++ b/add_login.js
@@ -10,11 +10,19 @@ function r(f){/in/.test(document.readyState)?setTimeout('r('+f+')',9):f()}
 r(function(){
     var formTargetIDs = ['registerform', 'loginform'];
     var idx;
+    var found;
+
     for (idx = 0; idx < formTargetIDs.length; ++idx) {
         var formElement = document.getElementById(formTargetIDs[idx]);
         if(formElement) {
+            found = true;
             addLoginToForm(formElement, idx);
         }
+    }
+
+    if ( found ) {
+        var url = loginwithamazon.ajaxurl + '&ts=' + Date.now();
+        loginwithamazon_script( url, window.document.getElementsByTagName('head')[0], 'loginwithamazon' );
     }
 });
 
@@ -43,4 +51,29 @@ function buildLoginElement(idx) {
     loginElement.style.textAlign = 'center';
     loginElement.innerHTML = '<a href="#" id="LoginWithAmazon-' + idx + '" style="display:inline-block;"><img border="0" alt="Login with Amazon" src="https://images-na.ssl-images-amazon.com/images/G/01/lwa/btnLWA_gold_156x32.png" width="156" height="32" style="display:block;" /></a>';
     return loginElement;
+}
+
+function activateLoginWithAmazonButtons(elementId) {
+    document.getElementById(elementId).onclick = function() {
+        amazon.Login.authorize( cfg.options, cfg.redirect );
+        return false;
+    };
+}
+
+function loginwithamazon_loader( cfg ) {
+    window.onAmazonLoginReady = function() {
+        amazon.Login.setClientId(cfg.client_id);
+        amazon.Login.setUseCookie(true);
+        cfg.logout && amazon.Login.logout();
+    };
+
+    loginwithamazon_script( 'https://api-cdn.amazon.com/sdk/login1.js', getElementById('amazon-root'), 'amazon-login-sdk' );
+}
+
+function loginwithamazon_script( url, container, id ) {
+    var a = document.createElement('script');
+    a.type = 'text/javascript'; a.async = true;
+    id && a.id = 'amazon-login-sdk';
+    a.src = url;
+    container && container.appendChild(a);
 }

--- a/add_login.js
+++ b/add_login.js
@@ -73,7 +73,9 @@ function loginwithamazon_loader( cfg ) {
 function loginwithamazon_script( url, container, id ) {
     var a = document.createElement('script');
     a.type = 'text/javascript'; a.async = true;
-    id && a.id = 'amazon-login-sdk';
+    if ( id ) {
+        a.id = 'amazon-login-sdk';
+    }
     a.src = url;
     container && container.appendChild(a);
 }

--- a/add_login.js
+++ b/add_login.js
@@ -67,7 +67,7 @@ function loginwithamazon_loader( cfg ) {
         cfg.logout && amazon.Login.logout();
     };
 
-    loginwithamazon_script( 'https://api-cdn.amazon.com/sdk/login1.js', getElementById('amazon-root'), 'amazon-login-sdk' );
+    loginwithamazon_script( 'https://api-cdn.amazon.com/sdk/login1.js', document.getElementById('amazon-root'), 'amazon-login-sdk' );
 }
 
 function loginwithamazon_script( url, container, id ) {

--- a/add_login.js
+++ b/add_login.js
@@ -10,11 +10,19 @@ function r(f){/in/.test(document.readyState)?setTimeout('r('+f+')',9):f()}
 r(function(){
     var formTargetIDs = ['registerform', 'loginform'];
     var idx;
+    var found;
+
     for (idx = 0; idx < formTargetIDs.length; ++idx) {
         var formElement = document.getElementById(formTargetIDs[idx]);
         if(formElement) {
+            found = true;
             addLoginToForm(formElement, idx);
         }
+    }
+
+    if ( found ) {
+        var url = loginwithamazon.ajaxurl + '&ts=' + Date.now();
+        loginwithamazon_script( url, window.document.getElementsByTagName('head')[0], 'loginwithamazon' );
     }
 });
 
@@ -43,4 +51,33 @@ function buildLoginElement(idx) {
     loginElement.style.textAlign = 'center';
     loginElement.innerHTML = '<a href="#" id="LoginWithAmazon-' + idx + '" style="display:inline-block;"><img border="0" alt="Login with Amazon" src="https://images-na.ssl-images-amazon.com/images/G/01/lwa/btnLWA_gold_156x32.png" width="156" height="32" style="display:block;" /></a>';
     return loginElement;
+}
+
+function activateLoginWithAmazonButtons(elementId) {
+    document.getElementById(elementId).onclick = function() {
+        var cfg = window.loginwithamazon_config;
+        amazon.Login.authorize( cfg.options, cfg.redirect );
+        return false;
+    };
+}
+
+function loginwithamazon_loader( cfg ) {
+    window.loginwithamazon_config = cfg;
+    window.onAmazonLoginReady = function() {
+        amazon.Login.setClientId(cfg.client_id);
+        amazon.Login.setUseCookie(true);
+        cfg.logout && amazon.Login.logout();
+    };
+
+    loginwithamazon_script( 'https://api-cdn.amazon.com/sdk/login1.js', document.getElementById('amazon-root'), 'amazon-login-sdk' );
+}
+
+function loginwithamazon_script( url, container, id ) {
+    var a = document.createElement('script');
+    a.type = 'text/javascript'; a.async = true;
+    if ( id ) {
+        a.id = 'amazon-login-sdk';
+    }
+    a.src = url;
+    container && container.appendChild(a);
 }

--- a/login_button.php
+++ b/login_button.php
@@ -9,56 +9,15 @@
  */
 defined('ABSPATH') or die('Access denied');
 
-if(get_option('loginwithamazon_client_id') && get_option('loginwithamazon_client_id') != '') {
-    add_action('wp_enqueue_scripts', 'loginwithamazon_enqueue_script');
-    add_action('login_enqueue_scripts', 'loginwithamazon_enqueue_script');
-    add_action('wp_footer', 'loginwithamazon_add_footer_script');
-    add_action('login_footer', 'loginwithamazon_add_footer_script');
-}
 
 function loginwithamazon_enqueue_script() {
-    wp_enqueue_script('loginwithamazon', LOGINWITHAMAZON__PLUGIN_URL . 'add_login.js');
+    $config = array(
+        'ajaxurl' => admin_url( 'admin-ajax.php?callback=loginwithamazon_loader', 'https' )
+    );
+    wp_localize_script( 'loginwithamazon', 'loginwithamazon', $config );
+    wp_enqueue_script('loginwithamazon', LOGINWITHAMAZON__PLUGIN_URL . 'add_login.js', array(), '1.0', true );
 }
 
 function loginwithamazon_add_footer_script() {
-    $popup = 'false';
-    if(!empty($_SERVER['HTTPS'])) {
-        $popup = 'true';
-    }
-
-    $csrf = LoginWithAmazonUtility::hmac($_SESSION[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY]);
-
-    ?>
-    <div id="amazon-root"></div>
-    <script type="text/javascript">
-
-        window.onAmazonLoginReady = function() {
-            amazon.Login.setClientId('<?php echo get_option('loginwithamazon_client_id'); ?>');
-            amazon.Login.setUseCookie(true);
-            <?php if(isset($_GET['loggedout']) && $_GET['loggedout'] == 'true'): ?>
-            amazon.Login.logout();
-            <?php endif; ?>
-        };
-        (function(d) {
-            var a = d.createElement('script'); a.type = 'text/javascript';
-            a.async = true; a.id = 'amazon-login-sdk';
-            a.src = 'https://api-cdn.amazon.com/sdk/login1.js';
-            d.getElementById('amazon-root').appendChild(a);
-        })(document);
-
-        function activateLoginWithAmazonButtons(elementId) {
-            document.getElementById(elementId).onclick = function() {
-                var options = {
-                    scope: 'profile',
-                    state: '<?php echo $csrf; ?>',
-                    popup: <?php echo $popup; ?>
-                };
-                amazon.Login.authorize(options, '<?php echo str_replace('http://', 'https://', site_url('wp-login.php')); ?>?amazonLogin=1');
-
-                return false;
-            };
-        }
-    </script>
-
-<?php
+    echo '<div id="amazon-root"></div>';
 }

--- a/login_button.php
+++ b/login_button.php
@@ -9,56 +9,15 @@
  */
 defined('ABSPATH') or die('Access denied');
 
-if(get_option('loginwithamazon_client_id') && get_option('loginwithamazon_client_id') != '') {
-    add_action('wp_enqueue_scripts', 'loginwithamazon_enqueue_script');
-    add_action('login_enqueue_scripts', 'loginwithamazon_enqueue_script');
-    add_action('wp_footer', 'loginwithamazon_add_footer_script');
-    add_action('login_footer', 'loginwithamazon_add_footer_script');
-}
 
 function loginwithamazon_enqueue_script() {
-    wp_enqueue_script('loginwithamazon', LOGINWITHAMAZON__PLUGIN_URL . 'add_login.js');
+    $config = array(
+        'ajaxurl' => admin_url( 'admin-ajax.php?action=loginwithamazon_config&callback=loginwithamazon_loader', 'https' )
+    );
+    wp_enqueue_script('loginwithamazon', LOGINWITHAMAZON__PLUGIN_URL . 'add_login.js', array(), '1.0', true );
+    wp_localize_script( 'loginwithamazon', 'loginwithamazon', $config );
 }
 
 function loginwithamazon_add_footer_script() {
-    $popup = 'false';
-    if(!empty($_SERVER['HTTPS'])) {
-        $popup = 'true';
-    }
-
-    $csrf = LoginWithAmazonUtility::hmac($_SESSION[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY]);
-
-    ?>
-    <div id="amazon-root"></div>
-    <script type="text/javascript">
-
-        window.onAmazonLoginReady = function() {
-            amazon.Login.setClientId('<?php echo get_option('loginwithamazon_client_id'); ?>');
-            amazon.Login.setUseCookie(true);
-            <?php if(isset($_GET['loggedout']) && $_GET['loggedout'] == 'true'): ?>
-            amazon.Login.logout();
-            <?php endif; ?>
-        };
-        (function(d) {
-            var a = d.createElement('script'); a.type = 'text/javascript';
-            a.async = true; a.id = 'amazon-login-sdk';
-            a.src = 'https://api-cdn.amazon.com/sdk/login1.js';
-            d.getElementById('amazon-root').appendChild(a);
-        })(document);
-
-        function activateLoginWithAmazonButtons(elementId) {
-            document.getElementById(elementId).onclick = function() {
-                var options = {
-                    scope: 'profile',
-                    state: '<?php echo $csrf; ?>',
-                    popup: <?php echo $popup; ?>
-                };
-                amazon.Login.authorize(options, '<?php echo str_replace('http://', 'https://', site_url('wp-login.php')); ?>?amazonLogin=1');
-
-                return false;
-            };
-        }
-    </script>
-
-<?php
+    echo '<div id="amazon-root"></div>';
 }

--- a/login_button.php
+++ b/login_button.php
@@ -12,10 +12,10 @@ defined('ABSPATH') or die('Access denied');
 
 function loginwithamazon_enqueue_script() {
     $config = array(
-        'ajaxurl' => admin_url( 'admin-ajax.php?callback=loginwithamazon_loader', 'https' )
+        'ajaxurl' => admin_url( 'admin-ajax.php?action=loginwithamazon_config&callback=loginwithamazon_loader', 'https' )
     );
-    wp_localize_script( 'loginwithamazon', 'loginwithamazon', $config );
     wp_enqueue_script('loginwithamazon', LOGINWITHAMAZON__PLUGIN_URL . 'add_login.js', array(), '1.0', true );
+    wp_localize_script( 'loginwithamazon', 'loginwithamazon', $config );
 }
 
 function loginwithamazon_add_footer_script() {

--- a/utility.php
+++ b/utility.php
@@ -104,8 +104,7 @@ class LoginWithAmazonUtility {
     }
 
     public static function createCsrfToken() {
-        //    $csrf = LoginWithAmazonUtility::hmac($_SESSION[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY]);
-
+	return self::hmac( self::getAuthenticatorKey() );
     }
 
     /**

--- a/utility.php
+++ b/utility.php
@@ -87,7 +87,7 @@ class LoginWithAmazonUtility {
         static $auth;
 
         if ( !isset( $auth ) ) {
-            if ( isset( $_COOKIE[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY] ) {
+            if ( isset( $_COOKIE[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY] ) ) {
                 $auth = $_COOKIE[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY];
             } else {
                 $auth = self::setAuthenticatorKey();

--- a/utility.php
+++ b/utility.php
@@ -79,15 +79,34 @@ class LoginWithAmazonUtility {
      * @return bool
      */
     public static function verifyCsrfToken($token) {
-        if ( isset($_SESSION[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY]) ) {
-            $true_token = self::hmac( $_SESSION[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY] );
-
-            return strcmp($token, $true_token) === 0;
-        }
-
-        return false;
+        $true_token = self::hmac( self::getAuthenticatorKey() );
+        return strcmp($token, $true_token) === 0;
     }
 
+    public static function getAuthenticatorKey() {
+        static $auth;
+
+        if ( !isset( $auth ) ) {
+            if ( isset( $_COOKIE[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY] ) {
+                $auth = $_COOKIE[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY];
+            } else {
+                $auth = self::setAuthenticatorKey();
+            }
+        }
+
+        return $auth;
+    }
+
+    public static function setAuthenticatorKey() {
+        $auth = wp_generate_password(64);
+        setcookie( LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY, $auth, 0, COOKIEPATH, COOKIE_DOMAIN, true );
+        return $auth;
+    }
+
+    public static function createCsrfToken() {
+        //    $csrf = LoginWithAmazonUtility::hmac($_SESSION[LoginWithAmazonUtility::$CSRF_AUTHENTICATOR_KEY]);
+
+    }
 
     /**
      * Get user email address from Amazon access token.


### PR DESCRIPTION
These changes attempt to support a CSRF token without the use of PHP Sessions, and are compatible with page caching mechanisms.

Some alternations also set the stage for conditional loading of code, shortcode support, and relocates some inline scripts.

The authenticator/seed for the CSRF token is stored in a session cookie set during the first request to JSON-P callback script. The script is only be requested on pages where the LWA button is present and runs prior to the loading and setup of the LoginWithAmazon JS.

Since the CSRF is visible to the client, it shouldn't be an issue that the seed is also visible. This makes me wonder if the CSRF itself shouldn't be stored in the cookie. That gets us one step closer to removing the AJAX call entirely.

The logout value in the JSON-P payload is a placeholder and needs some attention. When addressed, we should also consider clearing the authenticator session cookie.